### PR TITLE
Minor change proposals

### DIFF
--- a/index.html
+++ b/index.html
@@ -187,9 +187,10 @@ related notes.
 For new Recommendations listed <a href="#deliverables">below</a>, the Working
 Group will complete them and then will continue to maintain those
 specifications. For all published Recommendations, the Working Group will
-maintain those specifications ensuring but not introducing any
+maintain those specifications, ensuring that no
 <a href="https://www.w3.org/policies/process/20231103/#class-4">Class 4
-changes</a> except for serious security issues that arise.
+changes</a> are introduced except as needed to address any serious security
+issues that arise.
         </p>
 
         <section id="section-out-of-scope">


### PR DESCRIPTION
Some editorial changes. The noteworthy ones:

- The VC Overview WG Note, in its present form, does _not_ show all specifications listed in the deliverables section of the charter proposal. Better remove that reference from the motivation section (Only the reference to the deliverables. The reference to the Overview document itself stays.)
- I have slightly reordered the sections on deliverables, by pushing the "tentative" section to the end. The first two sections represent the WG's commitments, but the tentative section does not...
- I have anticipated the FPWD publications on the 30th of October: they mean that there will be an exclusion possibility starting from that date. So I added those to the list.
- Updated the history table including this work, and removing (well, commented) the entry of the WG starting under the new charter.

cc @philarcher @brentzundel @msporny


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/iherman/vc-charter-2026/pull/3.html" title="Last updated on Oct 27, 2025, 2:21 PM UTC (1c3a239)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/iherman/vc-charter-2026/3/cb3d213...1c3a239.html" title="Last updated on Oct 27, 2025, 2:21 PM UTC (1c3a239)">Diff</a>