### PR TITLE
New version to settle open issues

### DIFF
--- a/index.html
+++ b/index.html
@@ -449,7 +449,7 @@
                         Maintenance Specifications
                     </h3>
                     <p>
-                        No new normative features will be introduced for those specifications, except as needed to
+                        No new normative features will be introduced for the following specifications, except as needed to
                         address any serious privacy or security issues that arise, or to support the new Recommendations
                         produced by the group.
                     </p>


### PR DESCRIPTION
The following changes have been made on the charter

- Reformulated the scope section to avoid a reference to class 4 and the process document while maintaining (I believe) the intention. This should fix [issue 7](https://github.com/iherman/vc-charter-2026/issues/7) insofar as there is no reference to the process document (which is related to the change of existing document and not to new versions). By doing so, I believe the whole paragraph is cleaner now as for the scope of the WG
- Replaced "security" with "security or privacy" for the exception on new features for our existing specs. This should fix [issue 5](https://github.com/iherman/vc-charter-2026/issues/5).
- To my spite I rolled back on the change on the success criteria section, because the strategy team did not act on https://github.com/w3c/charter-drafts/pull/716. This means we are in sync with the charter template (although a new sync with the template will have to be done anyway if we move ahead). This should fix [issue 1](https://github.com/iherman/vc-charter-2026/issues/1).

@brentzundel @jandrieu @philarcher @msporny 


Fix #7 
Fix #5
Fix #1


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/iherman/vc-charter-2026/pull/9.html" title="Last updated on Dec 10, 2025, 11:03 AM UTC (9d6ca3d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/iherman/vc-charter-2026/9/7edb17a...9d6ca3d.html" title="Last updated on Dec 10, 2025, 11:03 AM UTC (9d6ca3d)">Diff</a>