### PR TITLE
Trivial fix to language ahead of list of maintenance specs

### DIFF
--- a/index.html
+++ b/index.html
@@ -449,7 +449,7 @@
                         Maintenance Specifications
                     </h3>
                     <p>
-                        No new normative features will be introduced for those specifications, except as needed to
+                        No new normative features will be introduced for the following specifications, except as needed to
                         address any serious privacy or security issues that arise, or to support the new Recommendations
                         produced by the group.
                     </p>


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/philarcher/vc-charter-2026/pull/10.html" title="Last updated on Dec 10, 2025, 10:59 AM UTC (a137b7f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/iherman/vc-charter-2026/10/89d8f7c...philarcher:a137b7f.html" title="Last updated on Dec 10, 2025, 10:59 AM UTC (a137b7f)">Diff</a>