### PR TITLE
Added a NAPHSIS liaison

### DIFF
--- a/index.html
+++ b/index.html
@@ -976,6 +976,12 @@
                             Ensure that the 23220-2 data model expressed by the ISO SC17 WG4 community is compatible
                             with the work of the Verifiable Credentials WG.
                         </dd>
+                        <dt><a href="https://www.naphsis.org">National Association for Public Health Statistics and Information Systems (NAPHSIS)</a>
+                        </dt>
+                        <dd>
+                            To ensure that vital records modeled and expressed by NAPHSIS members are compatible
+                            with the work of the Verifiable Credentials WG.
+                        </dd>
                     </dl>
                 </section>
             </section>


### PR DESCRIPTION
This came up as a request for liaison in a separate email:

> NAPHSIS is the National Association for Public Health Statistics and Information Systems, who represent United States vital records and public health statistics offices across the United States, including all 50 states, five territories, New York City, and the District of Columbia. They have an increasing interest in W3C Verifiable Credentials and should be listed as a liaison on the new VCWG Charter proposal.

This PR simply adds them to the liaison list


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-charter-2026/pull/12.html" title="Last updated on Dec 18, 2025, 4:46 PM UTC (cca2c4d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-charter-2026/12/4760679...cca2c4d.html" title="Last updated on Dec 18, 2025, 4:46 PM UTC (cca2c4d)">Diff</a>